### PR TITLE
Add sorting to node list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 presets.json
 .venv
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.db
 .DS_Store
 presets.json
+.venv

--- a/models.py
+++ b/models.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+@dataclass
+class Node:
+    user_id: str
+    short_name: str
+    long_name: str
+
+    @property
+    def short_padded(self, pad_to: int = 4) -> str:
+        """
+        short_name padded to four characters.
+        Emoji are two characters wide, which throws off Python's normal padding.
+        """
+        if (len(self.short_name) == 1): pad_to -= 1
+        return self.short_name.ljust(pad_to)
+    
+    @property
+    def node_list_disp(self):
+        return f"{self.user_id} {self.short_padded} | {self.long_name}"
+    

--- a/mqtt-connect.py
+++ b/mqtt-connect.py
@@ -1324,7 +1324,7 @@ def update_node_list():
             db_cursor = db_connection.cursor()
 
             # Fetch all nodes from the database
-            nodes = db_cursor.execute(f'SELECT user_id, long_name, short_name FROM {table_name}').fetchall()
+            nodes = db_cursor.execute(f'SELECT user_id, long_name, short_name FROM {table_name} ORDER BY long_name COLLATE NOCASE ASC').fetchall()
 
             # Clear the display
             nodeinfo_window.config(state=tk.NORMAL)

--- a/mqtt-connect.py
+++ b/mqtt-connect.py
@@ -37,6 +37,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 import paho.mqtt.client as mqtt
 
+from models import Node
 
 #################################
 ### Debug Options
@@ -955,12 +956,11 @@ def maybe_store_nodeinfo_in_db(info):
 
                 # Fetch the new record
                 new_record = db_cursor.execute(f'SELECT user_id, short_name, long_name FROM {table_name} WHERE user_id=?', (info.id,)).fetchone()
+                new_node = Node(*new_record)
 
                 # Display the new record in the nodeinfo_window widget
-                # Padding records to 5 since emoji are twice as wide
-                short_pad = 4 if len(new_record[1]) != 1 else 3
-                message = f"{new_record[0]} {new_record[1]:4} | {new_record[2]}"
-                update_gui(message, text_widget=nodeinfo_window)
+                # This inserts add the end, which breaks the sorting we start with. 
+                update_gui(new_node.node_list_disp, text_widget=nodeinfo_window)
             else:
                 # Check if long_name or short_name is different, update if necessary
                 if existing_record[1] != info.long_name or existing_record[2] != info.short_name:
@@ -1334,10 +1334,9 @@ def update_node_list():
             nodeinfo_window.delete('1.0', tk.END)
 
             # Display each node in the nodeinfo_window widget
-            for node in nodes:
-                short_pad = 4 if len(node[1]) != 1 else 3
-                message = f"{node[0]} {node[1]:{short_pad}} | {node[2]}\n"
-                nodeinfo_window.insert(tk.END, message)
+            for node_record in nodes:
+                node = Node(*node_record)
+                nodeinfo_window.insert(tk.END, node.node_list_disp + "\n")
 
             nodeinfo_window.config(state=tk.DISABLED)
 


### PR DESCRIPTION
I found the node list somewhat challenging to navigate, so this PR modifies the initial data load query to sort by short_name and then by long_name.

Because the box is a simple ScrolledText, newly found nodes post-init still get added to the end. Someone with more knowledge of tkinter or more time might know a better approach, such as calculating an insert point for new nodes. This PR's approach isn't perfect, but it means that *most* of the time, *most* nodes are sorted. 

This also includes some gitignore changes that should be fairly but not completely universal.